### PR TITLE
Fix copy-pasted plugin identity and surface process-listing errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,9 +23,9 @@ type Config struct {
 var (
 	plugin = Config{
 		PluginConfig: sensu.PluginConfig{
-			Name:     "check-cpu-usage",
+			Name:     "sensu-top-process",
 			Short:    "Check CPU usage and provide metrics",
-			Keyspace: "sensu.io/plugins/check-cpu-usage/config",
+			Keyspace: "sensu.io/plugins/sensu-top-process/config",
 		},
 	}
 
@@ -99,8 +99,12 @@ func ExpandName(name string, p *process.Process) string {
 
 func executeCheck(event *corev2.Event) (int, error) {
 	re := regexp.MustCompile(`-+|\s+|/+|:+|\.+|,+|=+`)
-	process, _ := process.Processes()
-	for _, p := range process {
+	procs, err := process.Processes()
+	if err != nil {
+		fmt.Printf("failed to list processes: %v\n", err)
+		return sensu.CheckStateUnknown, nil
+	}
+	for _, p := range procs {
 		cpu, _ := p.CPUPercent()
 		memory, _ := p.MemoryPercent()
 		name, _ := p.Name()


### PR DESCRIPTION
## Summary
- `Name`/`Keyspace` were still `check-cpu-usage` — a copy-pasted artifact from a different plugin. Sensu resolves annotation-based config overrides by keyspace, so an entity annotated under `sensu.io/plugins/check-cpu-usage/config` would be picked up by this check too, and vice versa if both plugins are deployed on the same entity.
- `process.Processes()`'s error was discarded (`_`). If process enumeration fails outright, the check silently returned `CheckStateOK` having evaluated nothing.

## Fix
- Corrected `Name`/`Keyspace` to `sensu-top-process`, matching the actual module/repo name.
- `process.Processes()` error is now checked; on failure the check returns `CheckStateUnknown` instead of a false OK.

## Test plan
- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] `go build .` succeeds
- [ ] Manually verify against a running host that config picked up under the new keyspace still applies (not available in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)